### PR TITLE
uninstall hive csv

### DIFF
--- a/multiclusterhub-operator/uninstall.sh
+++ b/multiclusterhub-operator/uninstall.sh
@@ -16,6 +16,3 @@ oc delete crd etcdclusters.etcd.database.coreos.com --ignore-not-found || true
 oc delete crd etcdrestores.etcd.database.coreos.com --ignore-not-found || true
 oc delete scc multicluster-scc --ignore-not-found || true
 oc delete scc multicloud-scc --ignore-not-found || true
-
-# hive
-oc delete csv hive -n hive $(oc get csv -n hive | tail -n +2 | cut -f 1 -d ' ') --ignore-not-found || true

--- a/multiclusterhub/uninstall.sh
+++ b/multiclusterhub/uninstall.sh
@@ -17,3 +17,6 @@ oc get clusterrole | grep "hive" | awk '{ print $1 }' | xargs oc delete clusterr
 oc get clusterrolebindings | grep "hive" | awk '{ print $1 }' | xargs oc delete clusterrolebinding
 for configmap in $(oc get configmap -n hive | tail -n +2 | cut -f 1 -d ' '); do oc delete configmap $configmap -n hive --ignore-not-found; done
 for webhook in $(oc get validatingwebhookconfiguration | grep hive | cut -f 1 -d ' '); do oc delete validatingwebhookconfiguration $webhook --ignore-not-found; done
+
+# hive
+oc delete csv hive -n hive $(oc get csv -n hive | tail -n +2 | cut -f 1 -d ' ') --ignore-not-found || true


### PR DESCRIPTION
I wanted to add some hive cleanup so for right now I added cleaning of the hive CSV.  However, should we also be cleaning up the hive and open-cluster-management namespaces too?  Or are there too many problems with `delete ns` hanging?