### PR TITLE
Add managed cluster documentation for downstream images

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n INSTALL_NAMESPACE
 
 ## Deploy managed cluster
 
-Run on the hub cluster:
+Run on the **hub cluster**:
 
 ```
 # Create a namespace managed cluster namespace on the hub cluster
@@ -273,7 +273,7 @@ oc get secret "${CLUSTER_NAME}"-import -n "${CLUSTER_NAME}" -o jsonpath={.data.c
 oc get secret "${CLUSTER_NAME}"-import -n "${CLUSTER_NAME}" -o jsonpath={.data.import\\.yaml} | base64 --decode > import.yaml
 ```
 
-Next apply the saved YAML manifests to your managed cluster:
+Next apply the saved YAML manifests to your **managed cluster**:
 
 ```
 # Change kubconfig to the managed cluster
@@ -305,7 +305,7 @@ kubectl get managedcluster ${CLUSTER_NAME}
 kubectl get pod -n open-cluster-management-agent-addon
 ```
 
-Test if it works by applying creating a `ManifestWork` in the Hub Cluster:
+Test if it works by applying creating a `ManifestWork` in the **hub cluster**:
 
 ```
 echo "apiVersion: work.open-cluster-management.io/v1
@@ -329,7 +329,7 @@ spec:
           restartPolicy: OnFailure" | kubectl apply -f -
 ```
 
-On the managed cluster validate that the hello pod is running:
+On the **managed cluster** validate that the hello pod is running:
 
 ```
 $ kubectl get pods -n default

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Use the following command to enable search
 oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n INSTALL_NAMESPACE
 ```
 
-## Deploy managed cluster
+### Deploy a managed cluster with downstream images
 
 Run on the **hub cluster**:
 


### PR DESCRIPTION
**Description of the change:**
Add documentation how to add a managed cluster by using downstream images.

**Motivation for the change:**
It does not work to deploy managed clusters by following the [documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/clusters/importing-a-target-managed-cluster-to-the-hub-cluster#importing-a-managed-cluster-with-the-cli) because some more tweaks are necessary.

A script may follow in the future but first I want to discuss the documentation and having an approve that this approach is correct.