### PR TITLE
Bail on `yq` failure

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -103,7 +103,12 @@ if [ ! -x "$(command -v yq)"  ]; then
         exit 1
     elif [ "${OS}" == "linux" ]; then # if linux, assume it is canary, and install yq
         echo "Attempting to install yq"
-        wget https://github.com/mikefarah/yq/releases/download/v4.12.2/yq_linux_amd64 -O ~/bin/yq && chmod +x ~/bin/yq
+        if [[ ":$PATH:" == *":$HOME/bin:"* ]]; then
+            YQ_PATH="$HOME/bin"
+        else
+            YQ_PATH="/usr/local/bin"
+        fi
+        wget https://github.com/mikefarah/yq/releases/download/v4.12.2/yq_linux_amd64 -O ${YQ_PATH}/yq && chmod +x ${YQ_PATH}/yq
         if [ ! -x "$(command -v yq)"  ]; then
             echo "ERROR: yq is required, but attempts to install it failed"
             exit 1

--- a/start.sh
+++ b/start.sh
@@ -104,6 +104,10 @@ if [ ! -x "$(command -v yq)"  ]; then
     elif [ "${OS}" == "linux" ]; then # if linux, assume it is canary, and install yq
         echo "Attempting to install yq"
         wget https://github.com/mikefarah/yq/releases/download/v4.12.2/yq_linux_amd64 -O ~/bin/yq && chmod +x ~/bin/yq
+        if [ ! -x "$(command -v yq)"  ]; then
+            echo "ERROR: yq is required, but attempts to install it failed"
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/open-cluster-management/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
- Update to use `/usr/local/bin/` instead of `~/bin/` for the `yq` installation
- Bail if the `yq` installation doesn't work

**Motivation for the change:**
- `yq` is required, so we should be exiting the script rather than continuing forward if `yq` doesn't work

Followup to:
- https://github.com/stolostron/deploy/pull/224

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->