### PR TITLE
Change the github org name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ I'm really glad you're reading this, because we need your help to make this proj
 
 If you haven't already, come find us on Slack ([#forum-acm](https://coreos.slack.com/archives/CTDEY6EEA) - private RedHat only link at this time). We want to help answer your questions about the `Open Cluster Management` organization.
 
-For documentation please see our 'work-in-progress' [docs](https://github.com/open-cluster-management/rhacm-docs/blob/doc_prod/README.md). Open a [doc issue](https://github.com/open-cluster-management/rhacm-docs/issues/new/choose) for any problems you may find, or clarifications you might suggest.
+For documentation please see our 'work-in-progress' [docs](https://github.com/stolostron/rhacm-docs/blob/doc_prod/README.md). Open a [doc issue](https://github.com/stolostron/rhacm-docs/issues/new/choose) for any problems you may find, or clarifications you might suggest.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you're a Red Hat associate or partner needing access to open-cluster-manageme
 
 ## Let's get started...
 
-You can find our __work-in-progress__ documentation [here](https://github.com/open-cluster-management/rhacm-docs/blob/doc_prod/README.md). Please read through the docs to find out how you can use the _open-cluster-management_ project. Oh, and please submit an issue for any problems you may find, or clarifications you might suggest.
+You can find our __work-in-progress__ documentation [here](https://github.com/stolostron/rhacm-docs/blob/doc_prod/README.md). Please read through the docs to find out how you can use the _open-cluster-management_ project. Oh, and please submit an issue for any problems you may find, or clarifications you might suggest.
 
 You can find information on how to contribute to this project and our docs project in our [CONTRIBUTING.md](CONTRIBUTING.md) doc.
 
@@ -69,18 +69,18 @@ You have multiple choices of installation:
   - [the hard way](#the-hard-way) - instructions to deploy _open-cluster-management_ with only `oc` commands.
   - [downstream images v2.0+](#deploying-downstream-builds-snapshots-for-product-quality-engineering-only-20) - instructions to deploy downstream images, i.e. for QE
 
-Either way you choose to go, you are going to need a `pull-secret` in order to gain access to our built images residing in our private [Quay environment](https://quay.io/open-cluster-management). Please follow the instructions [Prepare to deploy Open Cluster Management Instance](#prepare-to-deploy-open-cluster-management-instance-only-do-once) to get your `pull-secret` setup.
+Either way you choose to go, you are going to need a `pull-secret` in order to gain access to our built images residing in our private [Quay environment](https://quay.io/stolostron). Please follow the instructions [Prepare to deploy Open Cluster Management Instance](#prepare-to-deploy-stolostron-instance-only-do-once) to get your `pull-secret` setup.
 
 ## Prepare to deploy Open Cluster Management Instance (only do once)
 
 1. Clone this repo locally
     ```bash
-    git clone https://github.com/open-cluster-management/deploy.git
+    git clone https://github.com/stolostron/deploy.git
     ```
 
 2. Generate your pull-secret:
-   - ensure you have access to the quay org ([open-cluster-management](https://quay.io/repository/open-cluster-management/multiclusterhub-operator-index?tab=tags))
-   - to request access to [open-cluster-management](https://quay.io/repository/open-cluster-management/multiclusterhub-operator-index?tab=tags) in quay.io please contact the ACM CICD team via email at [acm-contact@redhat.com](mailto:acm-contact@redhat.com) or, if you have access to Red Hat CoreOS Slack you can contact us on our Slack Channel [#forum-acm-devops](https://coreos.slack.com/archives/CSZLMKPS5)) and indicate if you want upstream (`open-cluster-management`) or downstream (`acm-d`) repos (or both).  We'll need your quay ID.  Once the team indicates they've granted you access, open your Notifications at quay.io and accept the invitation(s) waiting for you.
+   - ensure you have access to the quay org ([stolostron](https://quay.io/repository/stolostron/multiclusterhub-operator-index?tab=tags))
+   - to request access to [stolostron](https://quay.io/repository/stolostron/multiclusterhub-operator-index?tab=tags) in quay.io please contact the ACM CICD team via email at [acm-contact@redhat.com](mailto:acm-contact@redhat.com) or, if you have access to Red Hat CoreOS Slack you can contact us on our Slack Channel [#forum-acm-devops](https://coreos.slack.com/archives/CSZLMKPS5)) and indicate if you want upstream (`stolostron`) or downstream (`acm-d`) repos (or both).  We'll need your quay ID.  Once the team indicates they've granted you access, open your Notifications at quay.io and accept the invitation(s) waiting for you.
    - go to [https://quay.io/user/tpouyer?tab=settings](https://quay.io/user/tpouyer?tab=settings) replacing `tpouyer` with your username
    - click on `Generate Encrypted Password`
    - enter your quay.io password
@@ -118,7 +118,7 @@ _Optionally_ `export DEBUG=true` for additional debugging output for 2.1+ releas
     ```
 
 2. When prompted for the SNAPSHOT tag, either press `Enter` to use the previous tag, or provide a new SNAPSHOT tag.
-    - UPSTREAM snapshot tags - https://quay.io/repository/open-cluster-management/acm-custom-registry?tab=tags
+    - UPSTREAM snapshot tags - https://quay.io/repository/stolostron/acm-custom-registry?tab=tags
     - DOWNSTREAM snapshot tag - https://quay.io/repository/acm-d/acm-custom-registry?tab=tags
     
     For example, your SNAPSHOT tag might resemble the following information:
@@ -177,7 +177,7 @@ To deploy a downstream build from `quay.io/acm-d` ensure that your OCP cluster m
    rm pull_secret.yaml
    ```
 
-   You can also set the pull secrets in the OpenShift console or using the [bootstrap repo](https://github.com/open-cluster-management/bootstrap#how-to-use) at cluster create time.
+   You can also set the pull secrets in the OpenShift console or using the [bootstrap repo](https://github.com/stolostron/bootstrap#how-to-use) at cluster create time.
 
     Your OpenShift main pull secret should contain an entry with `quay.io:443`.
     <pre>
@@ -255,14 +255,14 @@ for helmrelease in $(oc get helmreleases.apps.open-cluster-management.io | tail 
   ```
 
 2. Update the `kustomization.yaml` file in the `acm-operator` dir to set `newTag`
-  You can find a snapshot tag by viewing the list of tags available [here](https://quay.io/open-cluster-management/acm-custom-registry) Use a tag that has the word `SNAPSHOT` in it.
+  You can find a snapshot tag by viewing the list of tags available [here](https://quay.io/stolostron/acm-custom-registry) Use a tag that has the word `SNAPSHOT` in it.
   For downstream deploys, make sure to set `newName` differently, usually to `acm-d`.
     ```bash
     namespace: open-cluster-management
 
     images:
       - name: acm-custom-registry
-        newName: quay.io/open-cluster-management/acm-custom-registry
+        newName: quay.io/stolostron/acm-custom-registry
         newTag: 1.0.0-SNAPSHOT-2020-05-04-17-43-49
     ```
 

--- a/acm-operator/kustomization.yaml
+++ b/acm-operator/kustomization.yaml
@@ -7,7 +7,7 @@ generatorOptions:
 
 images:
   - name: acm-custom-registry
-    newName: quay.io/open-cluster-management/acm-custom-registry
+    newName: quay.io/stolostron/acm-custom-registry
     newTag: 2.3.0-SNAPSHOT-2021-05-18-17-51-57
 
 # list of Resource Config to be Applied

--- a/addons/observability/example-observability-cr.yaml
+++ b/addons/observability/example-observability-cr.yaml
@@ -3,7 +3,7 @@ kind: MultiClusterObservability
 metadata:
   name: observability
   annotations:
-    mco-imageRepository: quay.io/open-cluster-management
+    mco-imageRepository: quay.io/stolostron
     mco-imageTagSuffix: <SNAPSHOT>
 spec:
   storageConfigObject:

--- a/demo/README.md
+++ b/demo/README.md
@@ -8,7 +8,7 @@ Welcome to your first taste of Open Cluster Management (OCM).  We have collected
 - Deploy an application onto your managed cluster(s) using a subscription and placement rules
 
 
-We'll keep it brief and to the point in here... for our full documentation you should refer to our [doc site](https://github.com/open-cluster-management/rhacm-docs/blob/doc_stage/README.md).
+We'll keep it brief and to the point in here... for our full documentation you should refer to our [doc site](https://github.com/stolostron/rhacm-docs/blob/doc_stage/README.md).
 
 In here you'll find three sub-directories:
 
@@ -34,5 +34,5 @@ Now we're getting to the good stuff... [Add applications, channels, subscription
 You ever wanted to be a govenor?  Well now is you're opportunity... [Import policies into your OCM](./policies/README.md)
 
 ### Step 4
-Hey you didn't think all this was completely free did you?  You owe us some feedback... create some [product issues](https://github.com/open-cluster-management/deploy/issues) or maybe some [doc issues](https://github.com/open-cluster-management/rhacm-docs/issues).  We want to hear from you.  If you just have questions you can find us on Slack ([#forum-acm](https://coreos.slack.com/archives/CTDEY6EEA)).
+Hey you didn't think all this was completely free did you?  You owe us some feedback... create some [product issues](https://github.com/stolostron/deploy/issues) or maybe some [doc issues](https://github.com/stolostron/rhacm-docs/issues).  We want to hear from you.  If you just have questions you can find us on Slack ([#forum-acm](https://coreos.slack.com/archives/CTDEY6EEA)).
 

--- a/demo/app/guestbook/application.yaml
+++ b/demo/app/guestbook/application.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: open-cluster-management
 spec:
   type: GitHub
-  pathname: https://github.com/open-cluster-management/deploy.git
+  pathname: https://github.com/stolostron/deploy.git
 ---
 apiVersion: app.k8s.io/v1beta1
 kind: Application

--- a/demo/kind/import/endpoint.yaml
+++ b/demo/kind/import/endpoint.yaml
@@ -20,7 +20,7 @@ spec:
   iamPolicyController:
     enabled: true
   imagePullSecret: multiclusterhub-operator-pull-secret
-  imageRegistry: quay.io/open-cluster-management
+  imageRegistry: quay.io/stolostron
   policyController:
     enabled: true
   prometheusIntegration:

--- a/demo/kind/import/kustomization.yaml
+++ b/demo/kind/import/kustomization.yaml
@@ -16,7 +16,7 @@ secretGenerator:
 
 images:
   - name: endpoint-operator
-    newName: quay.io/open-cluster-management/endpoint-operator
+    newName: quay.io/stolostron/endpoint-operator
     newTag: 1.0.0-SNAPSHOT-2020-04-01-02-43-31
 
 resources:

--- a/demo/kind/kind-cluster.yaml
+++ b/demo/kind/kind-cluster.yaml
@@ -36,7 +36,7 @@ spec:
   clusterNamespace: <CLUSTER_NAME>
   iamPolicyController:
     enabled: true
-  imageRegistry: quay.io/open-cluster-management
+  imageRegistry: quay.io/stolostron
   policyController:
     enabled: true
   prometheusIntegration:

--- a/demo/policies/channel.yaml
+++ b/demo/policies/channel.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: open-cluster-management
 spec:
   type: GitHub
-  pathname: https://github.com/open-cluster-management/deploy.git
+  pathname: https://github.com/stolostron/deploy.git

--- a/dev/acm-operator/kustomization.yaml
+++ b/dev/acm-operator/kustomization.yaml
@@ -10,7 +10,7 @@ generatorOptions:
 
 images:
   - name: acm-custom-registry
-    newName: quay.io/open-cluster-management/acm-custom-registry
+    newName: quay.io/stolostron/acm-custom-registry
     newTag: 1.0.0-SNAPSHOT-2020-05-12-23-58-57
 
 # list of Resource Config to be Applied

--- a/dev/multicluster-hub-operator/kustomization.yaml
+++ b/dev/multicluster-hub-operator/kustomization.yaml
@@ -10,7 +10,7 @@ generatorOptions:
 
 images:
   - name: multicluster-hub-custom-registry
-    newName: quay.io/open-cluster-management/multicluster-hub-custom-registry
+    newName: quay.io/stolostron/multicluster-hub-custom-registry
     newTag: 1.0.0-SNAPSHOT-2020-05-12-23-58-57
 
 # list of Resource Config to be Applied

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -117,7 +117,7 @@ fi
 if [[ " $@ " =~ " --silent " ]]; then
     echo "* Silent mode"
 else
-    printf "Find snapshot tags @ https://quay.io/repository/open-cluster-management/acm-custom-registry?tab=tags\nEnter SNAPSHOT TAG: (Press ENTER for default: ${DEFAULT_SNAPSHOT})\n"
+    printf "Find snapshot tags @ https://quay.io/repository/stolostron/acm-custom-registry?tab=tags\nEnter SNAPSHOT TAG: (Press ENTER for default: ${DEFAULT_SNAPSHOT})\n"
     read -r SNAPSHOT_CHOICE
     if [ "${SNAPSHOT_CHOICE}" != "" ]; then
         DEFAULT_SNAPSHOT=${SNAPSHOT_CHOICE}
@@ -130,8 +130,8 @@ if [ "${DEFAULT_SNAPSHOT}" == "MUST_PROVIDE_SNAPSHOT" ]; then
 fi
 SNAPSHOT_PREFIX=${DEFAULT_SNAPSHOT%%\-*}
 
-# Set the custom registry repo, defaulted to quay.io/open-cluster-management, but accomodate custom config focused on quay.io/acm-d for donwstream tests
-CUSTOM_REGISTRY_REPO=${CUSTOM_REGISTRY_REPO:-"quay.io/open-cluster-management"}
+# Set the custom registry repo, defaulted to quay.io/stolostron, but accomodate custom config focused on quay.io/acm-d for donwstream tests
+CUSTOM_REGISTRY_REPO=${CUSTOM_REGISTRY_REPO:-"quay.io/stolostron"}
 
 # If the user sets the COMPOSITE_BUNDLE flag to "true", then set to the `acm` variants of variables, otherwise the multicluster-hub version.  
 if [[ "$COMPOSITE_BUNDLE" == "true" ]]; then OPERATOR_DIRECTORY="dev/acm-operator"; else OPERATOR_DIRECTORY="dev/multicluster-hub-operator"; fi;
@@ -242,8 +242,8 @@ docker run --network host \
 	--env waitInMinutes=10 \
 	--env mchImageRepository=${CUSTOM_REGISTRY_REPO} \
 	--volume ${KUBECONFIG}:/opt/.kube/config \
-	--volume ${RESULTS_DIR}:/go/src/github.com/open-cluster-management/multicloudhub-operator/test/results/ \
-	quay.io/open-cluster-management/multiclusterhub-operator-tests:${INSTALLER_IMAGE_TAG}
+	--volume ${RESULTS_DIR}:/go/src/github.com/stolostron/multicloudhub-operator/test/results/ \
+	quay.io/stolostron/multiclusterhub-operator-tests:${INSTALLER_IMAGE_TAG}
 
 ls -la ${RESULTS_DIR}
 

--- a/hack/nolimits.sh
+++ b/hack/nolimits.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Remove all limits on OCM pods https://github.com/open-cluster-management/backlog/issues/1073
+# Remove all limits on OCM pods https://github.com/stolostron/backlog/issues/1073
 
 kubectl patch deploy $(kubectl get deploy -l component=applicationui -o  jsonpath='{.items[0].metadata.name }')  \
    --type='json' -p '[{"op": "remove", "path": "/spec/template/spec/containers/0/resources/limits/cpu"}]'

--- a/hack/nuke.sh
+++ b/hack/nuke.sh
@@ -174,7 +174,7 @@ oc delete crd klusterletconfigs.agent.open-cluster-management.io || true
 oc delete clusterrole rcm-controller || true
 oc delete clusterrolebinding rcm-controller || true
 
-# workaround for https://github.com/open-cluster-management/backlog/issues/2915
+# workaround for https://github.com/stolostron/backlog/issues/2915
 oc delete apiservice v1.admission.cluster.open-cluster-management.io v1beta1.proxy.open-cluster-management.io
 oc delete ValidatingWebhookConfiguration managedclustervalidators.admission.cluster.open-cluster-management.io
 

--- a/multicluster-hub-operator/kustomization.yaml
+++ b/multicluster-hub-operator/kustomization.yaml
@@ -7,7 +7,7 @@ generatorOptions:
 
 images:
   - name: multicluster-hub-custom-registry
-    newName: quay.io/open-cluster-management/multicluster-hub-custom-registry
+    newName: quay.io/stolostron/multicluster-hub-custom-registry
     newTag: 1.0.0-SNAPSHOT-2020-05-12-23-58-57
 
 # list of Resource Config to be Applied

--- a/multiclusterengine/README.md
+++ b/multiclusterengine/README.md
@@ -29,7 +29,7 @@ $ ./multiclusterengine/start.sh
 ```
 
 2. When prompted for the SNAPSHOT tag, either press `Enter` to use the previous tag, or provide a new SNAPSHOT tag.
-    - UPSTREAM snapshot tags - https://quay.io/repository/open-cluster-management/cmb-custom-registry?tab=tags
+    - UPSTREAM snapshot tags - https://quay.io/repository/stolostron/cmb-custom-registry?tab=tags
     - DOWNSTREAM snapshot tags - https://quay.io/repository/acm-d/mce-custom-registry?tag=latest&tab=tags
 
 After the tag has been provided, the installation will continue. Currently the installation deploys and manages its components in the `multicluster-engine` namespace which it creates.

--- a/multiclusterengine/start.sh
+++ b/multiclusterengine/start.sh
@@ -4,7 +4,7 @@
 set -e
 
 DOWNSTREAM=${DOWNSTREAM:-"false"}
-_REGISTRY="quay.io/open-cluster-management"
+_REGISTRY="quay.io/stolostron"
 _IMAGE_NAME="cmb-custom-registry"
 
 if [ $DOWNSTREAM == "true" ]; then

--- a/multiclusterhub/uninstall.sh
+++ b/multiclusterhub/uninstall.sh
@@ -87,17 +87,17 @@ for rolebinding in $(oc get clusterrolebindings | grep mcm | cut -f 1 -d ' '); d
 oc get policies.policy.mcm.ibm.com --all-namespaces | tail -n +2 | awk '{ print $2 " -n " $1 }' | xargs oc patch policies.policy.mcm.ibm.com --type json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]' || true
 oc get policies.policy.mcm.ibm.com --all-namespaces | tail -n +2 | awk '{ print $2 " -n " $1 }' | xargs oc delete policies.policy.mcm.ibm.com --wait=false --ignore-not-found || true
 
-# Issue https://github.com/open-cluster-management/backlog/issues/1286
+# Issue https://github.com/stolostron/backlog/issues/1286
 oc delete crd compliances.compliance.mcm.ibm.com --wait=false --ignore-not-found || true
 oc delete crd policies.policy.mcm.ibm.com --wait=false --ignore-not-found || true
 
-# Issue https://github.com/open-cluster-management/backlog/issues/1794
+# Issue https://github.com/stolostron/backlog/issues/1794
 oc delete crd searchservices.search.acm.com --wait=false --ignore-not-found || true
 
-# Working on in https://github.com/open-cluster-management/backlog/issues/786
+# Working on in https://github.com/stolostron/backlog/issues/786
 for configmap in $(oc get configmap | grep ingress-controller | cut -f 1 -d ' '); do oc delete configmap $configmap --ignore-not-found; done
 
-# Working on in https://github.com/open-cluster-management/backlog/issues/787
+# Working on in https://github.com/stolostron/backlog/issues/787
 for secret in $(oc get Secret | grep cert-manager | cut -f 1 -d ' '); do oc delete Secret $secret --ignore-not-found; done
 
 # Issue pending


### PR DESCRIPTION
First pass at changing org references to stolostron, I left the references to the project name as `open-cluster-management` but changed the quay request project to match the actual repo name.

Changes include:
Github Links
Quay Links
Registry Updates