### PR TITLE
Doc update - add a /rhacm2 mirror in icsp

### DIFF
--- a/docs/deploy-from-brew.md
+++ b/docs/deploy-from-brew.md
@@ -78,28 +78,15 @@ spec:
     - brew.registry.redhat.io
     source: registry.redhat.io
   - mirrors:
+    - brew.registry.redhat.io/rhacm2
+    source: registry.redhat.io/rhacm2
+  - mirrors:
     - brew.registry.redhat.io
     source: registry.stage.redhat.io
   - mirrors:
     - brew.registry.redhat.io
     source: registry-proxy.engineering.redhat.com
 EOF
-```
-
-Note: If any of the images you are pulling are in `/rhacm2` then you may also need to edit the `rhacm-repo`
-ImageContentSourcePolicy.
-
-Change:
-```
-  - mirrors:
-    - quay.io:443/acm-d
-    source: registry.redhat.io/rhacm2
-```
-To:
-```
-  - mirrors:
-    - brew.registry.redhat.io/rhacm2
-    source: registry.redhat.io/rhacm2
 ```
 
 ## Deploying ACM from Brew


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/stolostron/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Original instructions said to modify the existing rhacm-repo ICSP for images in registry.redhat.io/rhacm2 but on some clusters there's a SelectorSyncSet which will revert this value back after a while.

Updating instead the custom example for the brew-registry ICSP to include a mirror for /rhacm2 path.

**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->