### PR TITLE
Allow start.sh to dynamically pick its channel

### DIFF
--- a/multiclusterengine/start.sh
+++ b/multiclusterengine/start.sh
@@ -40,6 +40,7 @@ else
 fi
 
 IMG="${_REPO}:${SNAPSHOT_CHOICE}" yq eval -i '.spec.image = env(IMG)' catalogsources/multicluster-engine.yaml
+VER="${SNAPSHOT_CHOICE:0:3}" yq eval -i '.spec.channel = "stable-"+ env(VER)' multiclusterengine/operator/subscription.yaml
 oc apply -f catalogsources/multicluster-engine.yaml
 oc create ns multicluster-engine --dry-run=client -o yaml | oc apply -f -
 oc apply -k multiclusterengine/operator/


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/stolostron/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
multiclusterengine/start.sh did not work for 2.1.0-backplane snapshots. Did not set the correct subscription channel.


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
I required the deployment of the 2.1.0-backplane snapshot.