### PR TITLE
uninstall.sh: Validate MultiClusterHub is deleted before continuing

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -53,6 +53,12 @@ kubectl delete -k multiclusterhub/ -n ${TARGET_NAMESPACE}
 echo "Sleeping for 200 seconds to allow resources to finalize ..."
 sleep 200
 
+kubectl get multiclusterhub >/dev/null 2>&1
+if [ $? -ne 1 ]; then
+    echo "ERROR: MultiClusterHub was not deleted! Make sure to remove resource dependencies"
+    exit 1
+fi
+
 kubectl delete -k multicluster-hub-operator/ -n ${TARGET_NAMESPACE}
 ./multicluster-hub-operator/uninstall.sh
 


### PR DESCRIPTION
Signed-off-by: michaelkot97 <michael.kot97@gmail.com>

**Description of the change:** Added a check that verifies the deletion of the `MultiClusterHub` resource before continuing with CRD and operator deletion in the `uninstall.sh` script.

**Motivation for the change:** The existence of some resources does not allow the deletion of the `MultiClusterHub` resource (e.g - MultiClusterObservability). When such resources exist, the script fails to delete the `MultiClusterHub` CR, but continues to delete its CRD. In such cases the uninstall process is not successful and leaves a corrupted instance of a MultiClusterHub. The next stages of the script should only run when the `MultiClusterHub` instance is really deleted.