### PR TITLE
Allow deploy on OCP 4.11

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -145,7 +145,7 @@ echo "* Using baseDomain: ${HOST_URL}"
 VER=`oc version | grep "Client Version:"`
 echo "* oc CLI ${VER}"
 
-if ! [[ $VER =~ .*[4-9]\.([3-9]|10)\..* ]]; then
+if ! [[ $VER =~ .*[4-9]\.([3-9]|10|11)\..* ]]; then
     echo "oc cli version 4.3 or greater required. Please visit https://access.redhat.com/downloads/content/290/ver=4.3/rhel---8/4.3.9/x86_64/product-software."
     exit 1
 fi


### PR DESCRIPTION
The regex expects OCP from 4.3 to 4.10. `start.sh` script fails with OCP
4.11. Change the regex to also match 4.11. This will allow deploy to be
run on OCP 4.11

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/stolostron/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->