### PR TITLE
Removing OC Client Check

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -145,11 +145,6 @@ echo "* Using baseDomain: ${HOST_URL}"
 VER=`oc version | grep "Client Version:"`
 echo "* oc CLI ${VER}"
 
-if ! [[ $VER =~ .*[4-9]\.([3-9]|10)\..* ]]; then
-    echo "oc cli version 4.3 or greater required. Please visit https://access.redhat.com/downloads/content/290/ver=4.3/rhel---8/4.3.9/x86_64/product-software."
-    exit 1
-fi
-
 QUAY_TOKEN_OVERRIDE="false"
 if [ ! -f ./prereqs/pull-secret.yaml ]; then
     echo "SECURITY NOTICE: The encrypted dockerconfigjson is stored in ./prereqs/pull-secret.yaml. If you want to change the value, delete the file and run start.sh"


### PR DESCRIPTION
Just not support lower than 4.3 and assuming a newer version of OC CLI is installed