### PR TITLE
Updates for search v2 (RHACM 2.7 and later)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ _Optionally_ `export DEBUG=true` for additional debugging output for 2.1+ releas
     -t modify the YAML but exit before apply the resources
     --silent, skip all prompting, uses the previous configuration
     --watch, will monitor the main Red Hat ACM pod deployments for up to 10min
-    --search, will activate search as part of the deployment.
+    --search, will activate search as part of the deployment. DEPRECATED: RHACM 2.7 and later, search is enabled by default.
     
-    $ ./start.sh --watch --search
+    $ ./start.sh --watch
     ```
 
 2. When prompted for the SNAPSHOT tag, either press `Enter` to use the previous tag, or provide a new SNAPSHOT tag.
@@ -227,7 +227,7 @@ export QUAY_TOKEN=<a quay token with quay.io:443 as the auth domain>
 
 ### Enable search later
 
-Use the following command to enable search
+For RHACM <=2.6, use the following command to enable search. Search is enabled by default in RHACM 2.7 and later.
 ```bash
 oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n INSTALL_NAMESPACE
 ```

--- a/docs/deploy-from-brew.md
+++ b/docs/deploy-from-brew.md
@@ -206,6 +206,7 @@ You'll likely want to poll the status array of the mch resource or watch the UI!
 
 #### Step 9: [Optional] Enable Search
 
+When deploying RHACM 2.7 or later, search is enabled by default. For RHACM <=2.6, use the following command to enable search.
 ```
 oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n ${TARGET_NAMESPACE}
 ```

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,6 @@
 # ./start.sh -t, this exits after modifying the files but not apply any of the yaml
 # ./start.sh --silent, this skips any questions, using the local files to apply the snapshot and secret
 # ./start.sh --watch, this monitors for status during the main deploy of Red Hat ACM
-# ./start.sh --search, this enables search, but turning on redis
 
 # CONSTANTS
 TOTAL_POD_COUNT_1X=35
@@ -72,18 +71,6 @@ function waitForPod() {
         sleep 3
         (( MINUTE = MINUTE + 3 ))
     done
-}
-
-function enable_search() {
-    if [[ ! " $@ " =~ " --skip-search " ]]; then
-        oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n ${TARGET_NAMESPACE}
-        echo "Search enabled"
-        echo ""
-    else
-        echo "Search was not enabled"
-        echo "Run 'oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n ${TARGET_NAMESPACE}' to enable search."
-        echo ""
-    fi
 }
 
 # fix sed issue on mac
@@ -464,8 +451,6 @@ if [[ " $@ " =~ " --watch " ]]; then
         fi
         exit 1
     else
-        #enable_search
-
         echo "#####"
         echo "* Red Hat ACM URL: https://${RHACM_URL}"
         echo ""
@@ -477,11 +462,11 @@ if [[ " $@ " =~ " --watch " ]]; then
     exit $COMPLETE
 fi
 
-echo "Search will only be automaticaly enabled with '--watch' is set."
-echo "Run 'oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n ${TARGET_NAMESPACE}' to enable search."
-echo ""
 echo "#####"
 echo "* Red Hat ACM URL: https://${RHACM_URL}"
+echo ""
+echo "* NOTE: For RHACM versions <=2.6, search is disabled by default."
+echo "  Run 'oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n ${TARGET_NAMESPACE}' to enable search."
 echo ""
 echo "* NOTE: For RHACM versions <2.6 or OCP versions <4.10, the console link can be found by running:"
 echo "  oc -n ${TARGET_NAMESPACE} get routes multicloud-console -o jsonpath='{.status.ingress[0].host}'"


### PR DESCRIPTION
**Description of the change:**
Starting in RHACM 2.7 search is enabled by default. Update documentation to reflect that it's no longer needed to enable search manually.

**Motivation for the change:**

