### PR TITLE
Add helper script to change the deployed MCO image

### DIFF
--- a/change_mco_image.sh
+++ b/change_mco_image.sh
@@ -5,7 +5,11 @@
 # use the image's digest.
 set -euo pipefail
 
-read -p "Please indicate the tag of your custom MCO image (https://quay.io/stolostron/multicluster-observability-operator): " mco_image_tag
+if [ -z "${mco_image_tag+x}" ]; then
+    read -p "Please indicate the tag of your custom MCO image (https://quay.io/stolostron/multicluster-observability-operator): " mco_image_tag
+else
+    echo "Using MCO tag '$mco_image_tag'"
+fi
 
 digest=$(curl -I -s -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://quay.io/v2/stolostron/multicluster-observability-operator/manifests/$mco_image_tag" | grep -i "Docker-Content-Digest" | awk '{print $2}' | tr -d '\r')
 
@@ -38,13 +42,13 @@ csv_path="$temp_folder"/acm.csv.yaml
 
 oc get -n open-cluster-management csv "$csv_name" -o yaml >"$csv_path"
 
-sed -i'' -E "s|value: registry\\.redhat\\.io/rhacm2/multicluster-observability-rhel8-operator@(.*)\$|value: $pr_image|g" "$csv_path"
-sed -i'' -E "s|image: registry\\.redhat\\.io/rhacm2/multicluster-observability-rhel8-operator@(.*)\$|value: $pr_image|g" "$csv_path"
+sed -i'.backup' -E "s|value: registry\\.redhat\\.io/rhacm2/multicluster-observability-rhel8-operator@(.*)\$|value: $pr_image|g" "$csv_path"
+sed -i'.backup' -E "s|image: registry\\.redhat\\.io/rhacm2/multicluster-observability-rhel8-operator@(.*)\$|value: $pr_image|g" "$csv_path"
 
-sed -i'' -E "s|value: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)\$|value: $pr_image|g" "$csv_path"
-sed -i'' -E "s|image: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)\$|image: $pr_image|g" "$csv_path"
+sed -i'.backup' -E "s|value: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)\$|value: $pr_image|g" "$csv_path"
+sed -i'.backup' -E "s|image: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)\$|image: $pr_image|g" "$csv_path"
 
-oc apply -f "$csv_path" -n open-cluster-management
+oc replace -f "$csv_path" -n open-cluster-management
 rm -rf "$temp_folder"
 
 echo "ClusterServiceVersion for ACM patched. Please wait for the reconciliation loop to update pods"

--- a/change_mco_image.sh
+++ b/change_mco_image.sh
@@ -38,8 +38,11 @@ csv_path="$temp_folder"/acm.csv.yaml
 
 oc get -n open-cluster-management csv "$csv_name" -o yaml >"$csv_path"
 
-sed -i'' -E "s|value: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)|value: $pr_image|g" "$csv_path"
-sed -i'' -E "s|image: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)|image: $pr_image|g" "$csv_path"
+sed -i'' -E "s|value: registry\\.redhat\\.io/rhacm2/multicluster-observability-rhel8-operator@(.*)\$|value: $pr_image|g" "$csv_path"
+sed -i'' -E "s|image: registry\\.redhat\\.io/rhacm2/multicluster-observability-rhel8-operator@(.*)\$|value: $pr_image|g" "$csv_path"
+
+sed -i'' -E "s|value: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)\$|value: $pr_image|g" "$csv_path"
+sed -i'' -E "s|image: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)\$|image: $pr_image|g" "$csv_path"
 
 oc apply -f "$csv_path" -n open-cluster-management
 rm -rf "$temp_folder"

--- a/change_mco_image.sh
+++ b/change_mco_image.sh
@@ -38,8 +38,8 @@ csv_path="$temp_folder"/acm.csv.yaml
 
 oc get -n open-cluster-management csv "$csv_name" -o yaml >"$csv_path"
 
-sed -i '' -E "s|value: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)|value: $pr_image|g" "$csv_path"
-sed -i '' -E "s|image: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)|image: $pr_image|g" "$csv_path"
+sed -i'' -E "s|value: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)|value: $pr_image|g" "$csv_path"
+sed -i'' -E "s|image: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)|image: $pr_image|g" "$csv_path"
 
 oc apply -f "$csv_path" -n open-cluster-management
 rm -rf "$temp_folder"

--- a/change_mco_image.sh
+++ b/change_mco_image.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# This script can be used to easily change the image used by the mutlicluster-observability-operator
+# by editing the ClusterServiceVersion resource. It only works with tags coming from
+# https://quay.io/stolostron/multicluster-observability-operator and it will always
+# use the image's digest.
+set -euo pipefail
+
+read -p "Please indicate the tag of your custom MCO image (https://quay.io/stolostron/multicluster-observability-operator): " mco_image_tag
+
+digest=$(curl -I -s -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://quay.io/v2/stolostron/multicluster-observability-operator/manifests/$mco_image_tag" | grep -i "Docker-Content-Digest" | awk '{print $2}' | tr -d '\r')
+
+echo "Fetched digest from Quay: $digest"
+
+pr_image="quay.io/stolostron/multicluster-observability-operator@$digest"
+echo "Will deploy PR image: $pr_image"
+
+csv_name=$(oc get -n open-cluster-management csv --selector operators.coreos.com/advanced-cluster-management.open-cluster-management -o json | jq -r '.items[0].metadata.name')
+echo "Will use CSV with name: $csv_name"
+
+read -p "Do you want to proceed? [y/N] " answer
+
+case $answer in
+[yY]*)
+    echo "Proceeding."
+    ;;
+[nN]* | "")
+    echo "Aborting."
+    exit 1
+    ;;
+*)
+    echo "Invalid answer. Exiting."
+    exit 1
+    ;;
+esac
+
+temp_folder=$(mktemp -d)
+csv_path="$temp_folder"/acm.csv.yaml
+
+oc get -n open-cluster-management csv "$csv_name" -o yaml >"$csv_path"
+
+sed -i '' -E "s|value: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)|value: $pr_image|g" "$csv_path"
+sed -i '' -E "s|image: quay\\.io/stolostron/multicluster-observability-operator@([^\"]*)|image: $pr_image|g" "$csv_path"
+
+oc apply -f "$csv_path" -n open-cluster-management
+rm -rf "$temp_folder"
+
+echo "ClusterServiceVersion for ACM patched. Please wait for the reconciliation loop to update pods"


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/stolostron/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Added a small shell script to automate changing the MCO image deployed in a cluster through the CSV resource.

**Motivation for the change:**

Manual work that has many steps which can have mistakes or be forgotten.