### PR TITLE
Add cmo config revert step to observability cleanup script

### DIFF
--- a/hack/cleanup-managed-cluster.sh
+++ b/hack/cleanup-managed-cluster.sh
@@ -46,4 +46,5 @@ for crd in "${component_crds[@]}"; do
 	${KUBECTL} delete crd ${crd}
 done
 
+${KUBECTL} -n ${OPERATOR_NAMESPACE} exec $(${KUBECTL} -n ${OPERATOR_NAMESPACE} get pod -l name=endpoint-observability-operator -o=name) -- ./cmo-config-revert
 ${KUBECTL} delete namespace ${OPERATOR_NAMESPACE}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/stolostron/deploy/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This change allows a user to manually cleanup and revert the cluster monitoring configuration in in the openshift-monitoring namespace.

Typically the endpointmetrics operator initiates this step via a finalizer on the Observability Addon in the Hub. However if the Hub and Managed Cluster become incompatible for any reason, we may need some manual cleanup.



Depends on https://github.com/stolostron/multicluster-observability-operator/pull/1591

**Motivation for the change:**

https://issues.redhat.com/browse/ACM-13149

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->